### PR TITLE
Fix `to_binary()` length

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>com.goterl</groupId>
             <artifactId>lazysodium-java</artifactId>
-            <version>5.0.1</version>
+            <version>5.1.0</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.jna</groupId>

--- a/src/main/java/com/ltonetwork/client/core/AccountFactory.java
+++ b/src/main/java/com/ltonetwork/client/core/AccountFactory.java
@@ -204,8 +204,8 @@ public class AccountFactory {
         return _address;
     }
 
-    protected byte getNetworkByte(){
-        if(this.network.equals("T")) return (byte) 84;
+    protected byte getNetworkByte() {
+        if (this.network.equals("T")) return (byte) 84;
         else return (byte) 76;
     }
 }

--- a/src/main/java/com/ltonetwork/client/core/transacton/Anchor.java
+++ b/src/main/java/com/ltonetwork/client/core/transacton/Anchor.java
@@ -3,6 +3,7 @@ package com.ltonetwork.client.core.transacton;
 import com.google.common.primitives.Bytes;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
+import com.google.common.primitives.Shorts;
 import com.ltonetwork.client.exceptions.BadMethodCallException;
 import com.ltonetwork.client.types.Encoding;
 import com.ltonetwork.client.types.JsonObject;
@@ -46,17 +47,21 @@ public class Anchor extends Transaction {
 
         ArrayList<Byte> anchorsBytes = new ArrayList<>();
         for (String anchor : anchors) {
-            for (Byte anc : Encoder.base58Decode(anchor)) {
+            byte[] decodedAnchor = Encoder.base58Decode(anchor);
+            byte[] ancLen = Shorts.toByteArray((short) decodedAnchor.length);
+            anchorsBytes.add(ancLen[0]);
+            anchorsBytes.add(ancLen[1]);
+            for (Byte anc : decodedAnchor) {
                 anchorsBytes.add(anc);
             }
         }
 
         return Bytes.concat(
-                Longs.toByteArray(this.type),
-                Longs.toByteArray(this.version),
-                this.senderPublicKey.toBase58().getBytes(StandardCharsets.UTF_8),
-                Ints.toByteArray(anchors.size()),
-                Bytes.toArray(anchorsBytes),
+                new byte[]{this.type},
+                new byte[]{this.version},
+                this.senderPublicKey.toRaw(),
+                Shorts.toByteArray((short) anchors.size()),
+                Bytes.toArray(anchorsBytes), // includes each anchor's length and value
                 Longs.toByteArray(this.timestamp),
                 Longs.toByteArray(this.fee)
         );

--- a/src/main/java/com/ltonetwork/client/core/transacton/Anchor.java
+++ b/src/main/java/com/ltonetwork/client/core/transacton/Anchor.java
@@ -1,7 +1,6 @@
 package com.ltonetwork.client.core.transacton;
 
 import com.google.common.primitives.Bytes;
-import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.common.primitives.Shorts;
 import com.ltonetwork.client.exceptions.BadMethodCallException;

--- a/src/main/java/com/ltonetwork/client/core/transacton/Association.java
+++ b/src/main/java/com/ltonetwork/client/core/transacton/Association.java
@@ -3,6 +3,7 @@ package com.ltonetwork.client.core.transacton;
 import com.google.common.primitives.Bytes;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
+import com.google.common.primitives.Shorts;
 import com.ltonetwork.client.exceptions.BadMethodCallException;
 import com.ltonetwork.client.types.Address;
 import com.ltonetwork.client.types.Encoding;
@@ -50,10 +51,10 @@ public class Association extends Transaction {
         }
 
         byte[] ret = Bytes.concat(
-                Longs.toByteArray(this.type),
-                Longs.toByteArray(this.version),
-                this.senderPublicKey.toBase58().getBytes(StandardCharsets.UTF_8),
-                new byte[this.getNetwork()],
+                new byte[]{this.type},
+                new byte[]{this.version},
+                new byte[]{this.getNetwork()},
+                this.senderPublicKey.toRaw(),
                 Encoder.base58Decode(this.party.getAddress()),
                 Ints.toByteArray(associationType)
         );
@@ -62,9 +63,13 @@ public class Association extends Transaction {
             byte[] rawHash = Encoder.base58Decode(this.hash);
             ret = Bytes.concat(
                     ret,
-                    Ints.toByteArray(1),
-                    Ints.toByteArray(rawHash.length),
+                    new byte[]{(byte) 1},
+                    Shorts.toByteArray((short) rawHash.length),
                     rawHash);
+        } else {
+            ret = Bytes.concat(
+                    ret,
+                    new byte[]{(byte) 0});
         }
 
         return Bytes.concat(

--- a/src/main/java/com/ltonetwork/client/core/transacton/CancelLease.java
+++ b/src/main/java/com/ltonetwork/client/core/transacton/CancelLease.java
@@ -33,12 +33,13 @@ public class CancelLease extends Transaction {
         }
 
         return Bytes.concat(
-                Longs.toByteArray(this.type),
-                Longs.toByteArray(this.version),
-                new byte[this.getNetwork()],
-                this.senderPublicKey.toBase58().getBytes(StandardCharsets.UTF_8),
+                new byte[]{this.type},
+                new byte[]{this.version},
+                this.senderPublicKey.toRaw(),
+                new byte[]{this.getNetwork()},
                 Longs.toByteArray(this.timestamp),
-                Longs.toByteArray(this.fee)
+                Longs.toByteArray(this.fee),
+                leaseId.getBytes(StandardCharsets.UTF_8)
         );
     }
 }

--- a/src/main/java/com/ltonetwork/client/core/transacton/CancelSponsor.java
+++ b/src/main/java/com/ltonetwork/client/core/transacton/CancelSponsor.java
@@ -36,10 +36,10 @@ public class CancelSponsor extends Transaction {
         }
 
         return Bytes.concat(
-                Longs.toByteArray(this.type),
-                Longs.toByteArray(this.version),
-                new byte[this.getNetwork()],
-                this.senderPublicKey.toBase58().getBytes(StandardCharsets.UTF_8),
+                new byte[]{this.type},
+                new byte[]{this.version},
+                this.senderPublicKey.toRaw(),
+                new byte[]{this.getNetwork()},
                 Encoder.base58Decode(this.recipient.getAddress()),
                 Longs.toByteArray(this.timestamp),
                 Longs.toByteArray(this.fee)

--- a/src/main/java/com/ltonetwork/client/core/transacton/CancelSponsor.java
+++ b/src/main/java/com/ltonetwork/client/core/transacton/CancelSponsor.java
@@ -7,8 +7,6 @@ import com.ltonetwork.client.types.Address;
 import com.ltonetwork.client.types.JsonObject;
 import com.ltonetwork.client.utils.Encoder;
 
-import java.nio.charset.StandardCharsets;
-
 public class CancelSponsor extends Transaction {
     private final static long MINIMUM_FEE = 500_000_000;
     private final static byte TYPE = 19;

--- a/src/main/java/com/ltonetwork/client/core/transacton/Lease.java
+++ b/src/main/java/com/ltonetwork/client/core/transacton/Lease.java
@@ -8,8 +8,6 @@ import com.ltonetwork.client.types.Address;
 import com.ltonetwork.client.types.JsonObject;
 import com.ltonetwork.client.utils.Encoder;
 
-import java.nio.charset.StandardCharsets;
-
 public class Lease extends Transaction {
     private final static long MINIMUM_FEE = 100_000_000;
     private final static byte TYPE = 8;
@@ -44,13 +42,13 @@ public class Lease extends Transaction {
         }
 
         return Bytes.concat(
-                Longs.toByteArray(this.type),
-                Longs.toByteArray(this.version),
-                this.senderPublicKey.toBase58().getBytes(StandardCharsets.UTF_8),
-                Longs.toByteArray(this.timestamp),
+                new byte[]{this.type},
+                new byte[]{this.version},
+                this.senderPublicKey.toRaw(),
+                Encoder.base58Decode(this.recipient.getAddress()),
                 Longs.toByteArray(this.amount),
                 Longs.toByteArray(this.fee),
-                Encoder.base58Decode(this.recipient.getAddress())
+                Longs.toByteArray(this.timestamp)
         );
     }
 }

--- a/src/main/java/com/ltonetwork/client/core/transacton/MassTransfer.java
+++ b/src/main/java/com/ltonetwork/client/core/transacton/MassTransfer.java
@@ -1,7 +1,6 @@
 package com.ltonetwork.client.core.transacton;
 
 import com.google.common.primitives.Bytes;
-import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.common.primitives.Shorts;
 import com.ltonetwork.client.exceptions.BadMethodCallException;
@@ -11,7 +10,6 @@ import com.ltonetwork.client.types.Encoding;
 import com.ltonetwork.client.types.JsonObject;
 import com.ltonetwork.client.utils.Encoder;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 public class MassTransfer extends Transaction {

--- a/src/main/java/com/ltonetwork/client/core/transacton/MassTransfer.java
+++ b/src/main/java/com/ltonetwork/client/core/transacton/MassTransfer.java
@@ -3,6 +3,7 @@ package com.ltonetwork.client.core.transacton;
 import com.google.common.primitives.Bytes;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
+import com.google.common.primitives.Shorts;
 import com.ltonetwork.client.exceptions.BadMethodCallException;
 import com.ltonetwork.client.exceptions.InvalidArgumentException;
 import com.ltonetwork.client.types.Address;
@@ -72,10 +73,10 @@ public class MassTransfer extends Transaction {
         }
 
         byte[] ret = Bytes.concat(
-                Longs.toByteArray(this.type),
-                Longs.toByteArray(this.version),
-                this.senderPublicKey.toBase58().getBytes(StandardCharsets.UTF_8),
-                Ints.toByteArray(transfers.size())
+                new byte[]{this.type},
+                new byte[]{this.version},
+                this.senderPublicKey.toRaw(),
+                Shorts.toByteArray((short) transfers.size())
         );
 
         ArrayList<Byte> transfersBytes = new ArrayList<>();
@@ -92,14 +93,14 @@ public class MassTransfer extends Transaction {
         ret = Bytes.concat(
                 ret,
                 Bytes.toArray(transfersBytes),
-                Longs.toByteArray(this.timestamp),
-                Longs.toByteArray(this.fee)
+                Longs.toByteArray(this.fee),
+                Longs.toByteArray(this.timestamp)
         );
 
         if (attachment != null) {
             ret = Bytes.concat(
                     ret,
-                    Ints.toByteArray(attachment.length()),
+                    Shorts.toByteArray((short) attachment.length()),
                     Encoder.base58Decode(this.attachment)
             );
         }

--- a/src/main/java/com/ltonetwork/client/core/transacton/RevokeAssociation.java
+++ b/src/main/java/com/ltonetwork/client/core/transacton/RevokeAssociation.java
@@ -3,6 +3,7 @@ package com.ltonetwork.client.core.transacton;
 import com.google.common.primitives.Bytes;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
+import com.google.common.primitives.Shorts;
 import com.ltonetwork.client.exceptions.BadMethodCallException;
 import com.ltonetwork.client.types.Address;
 import com.ltonetwork.client.types.Encoding;
@@ -49,10 +50,10 @@ public class RevokeAssociation extends Transaction {
         }
 
         byte[] ret = Bytes.concat(
-                Longs.toByteArray(this.type),
-                Longs.toByteArray(this.version),
-                this.senderPublicKey.toBase58().getBytes(StandardCharsets.UTF_8),
-                new byte[this.getNetwork()],
+                new byte[]{this.type},
+                new byte[]{this.version},
+                this.senderPublicKey.toRaw(),
+                new byte[]{this.getNetwork()},
                 Encoder.base58Decode(this.party.getAddress()),
                 Ints.toByteArray(associationType)
         );
@@ -61,9 +62,13 @@ public class RevokeAssociation extends Transaction {
             byte[] rawHash = Encoder.base58Decode(this.hash);
             ret = Bytes.concat(
                     ret,
-                    Ints.toByteArray(1),
-                    Ints.toByteArray(rawHash.length),
+                    new byte[]{(byte) 1},
+                    Shorts.toByteArray((short) rawHash.length),
                     rawHash);
+        } else {
+            ret = Bytes.concat(
+                    ret,
+                    new byte[]{(byte) 0});
         }
 
         return Bytes.concat(

--- a/src/main/java/com/ltonetwork/client/core/transacton/SetScript.java
+++ b/src/main/java/com/ltonetwork/client/core/transacton/SetScript.java
@@ -3,6 +3,7 @@ package com.ltonetwork.client.core.transacton;
 import com.google.common.primitives.Bytes;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
+import com.google.common.primitives.Shorts;
 import com.ltonetwork.client.exceptions.BadMethodCallException;
 import com.ltonetwork.client.types.JsonObject;
 import com.ltonetwork.client.utils.Encoder;
@@ -53,11 +54,12 @@ public class SetScript extends Transaction {
         byte[] binaryScript = Encoder.base64Decode(this.script.replaceAll("^(base64:)?", ""));
 
         return Bytes.concat(
-                Longs.toByteArray(this.type),
-                Longs.toByteArray(this.version),
-                new byte[this.getNetwork()],
-                this.senderPublicKey.toBase58().getBytes(StandardCharsets.UTF_8),
-                Ints.toByteArray(binaryScript.length),
+                new byte[]{this.type},
+                new byte[]{this.version},
+                new byte[]{this.getNetwork()},
+                this.senderPublicKey.toRaw(),
+                new byte[]{(byte) 1},
+                Shorts.toByteArray((short) binaryScript.length),
                 binaryScript,
                 Longs.toByteArray(this.fee),
                 Longs.toByteArray(this.timestamp)

--- a/src/main/java/com/ltonetwork/client/core/transacton/SetScript.java
+++ b/src/main/java/com/ltonetwork/client/core/transacton/SetScript.java
@@ -1,14 +1,11 @@
 package com.ltonetwork.client.core.transacton;
 
 import com.google.common.primitives.Bytes;
-import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.common.primitives.Shorts;
 import com.ltonetwork.client.exceptions.BadMethodCallException;
 import com.ltonetwork.client.types.JsonObject;
 import com.ltonetwork.client.utils.Encoder;
-
-import java.nio.charset.StandardCharsets;
 
 public class SetScript extends Transaction {
     private final static long MINIMUM_FEE = 500_000_000;

--- a/src/main/java/com/ltonetwork/client/core/transacton/Sponsor.java
+++ b/src/main/java/com/ltonetwork/client/core/transacton/Sponsor.java
@@ -7,8 +7,6 @@ import com.ltonetwork.client.types.Address;
 import com.ltonetwork.client.types.JsonObject;
 import com.ltonetwork.client.utils.Encoder;
 
-import java.nio.charset.StandardCharsets;
-
 public class Sponsor extends Transaction {
     private final static long MINIMUM_FEE = 500_000_000;
     private final static byte TYPE = 18;

--- a/src/main/java/com/ltonetwork/client/core/transacton/Sponsor.java
+++ b/src/main/java/com/ltonetwork/client/core/transacton/Sponsor.java
@@ -35,10 +35,10 @@ public class Sponsor extends Transaction {
         }
 
         return Bytes.concat(
-                Longs.toByteArray(this.type),
-                Longs.toByteArray(this.version),
-                new byte[this.getNetwork()],
-                this.senderPublicKey.toBase58().getBytes(StandardCharsets.UTF_8),
+                new byte[]{this.type},
+                new byte[]{this.version},
+                new byte[]{this.getNetwork()},
+                this.senderPublicKey.toRaw(),
                 Encoder.base58Decode(this.recipient.getAddress()),
                 Longs.toByteArray(this.timestamp),
                 Longs.toByteArray(this.fee)

--- a/src/main/java/com/ltonetwork/client/core/transacton/Transfer.java
+++ b/src/main/java/com/ltonetwork/client/core/transacton/Transfer.java
@@ -3,6 +3,7 @@ package com.ltonetwork.client.core.transacton;
 import com.google.common.primitives.Bytes;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
+import com.google.common.primitives.Shorts;
 import com.ltonetwork.client.exceptions.BadMethodCallException;
 import com.ltonetwork.client.exceptions.InvalidArgumentException;
 import com.ltonetwork.client.types.Address;
@@ -56,9 +57,9 @@ public class Transfer extends Transaction {
         }
 
         byte[] binaryAttachment = Bytes.concat(
-                Longs.toByteArray(this.type),
-                Longs.toByteArray(this.version),
-                this.senderPublicKey.toBase58().getBytes(StandardCharsets.UTF_8),
+                new byte[]{this.type},
+                new byte[]{this.version},
+                this.senderPublicKey.toRaw(),
                 Longs.toByteArray(this.timestamp),
                 Longs.toByteArray(this.amount),
                 Longs.toByteArray(this.fee),
@@ -67,7 +68,7 @@ public class Transfer extends Transaction {
         if (attachment != null) {
             binaryAttachment = Bytes.concat(
                     binaryAttachment,
-                    Ints.toByteArray(attachment.length()),
+                    Shorts.toByteArray((short) attachment.length()),
                     Encoder.base58Decode(this.attachment)
             );
         }

--- a/src/main/java/com/ltonetwork/client/core/transacton/Transfer.java
+++ b/src/main/java/com/ltonetwork/client/core/transacton/Transfer.java
@@ -1,7 +1,6 @@
 package com.ltonetwork.client.core.transacton;
 
 import com.google.common.primitives.Bytes;
-import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.common.primitives.Shorts;
 import com.ltonetwork.client.exceptions.BadMethodCallException;
@@ -10,8 +9,6 @@ import com.ltonetwork.client.types.Address;
 import com.ltonetwork.client.types.Encoding;
 import com.ltonetwork.client.types.JsonObject;
 import com.ltonetwork.client.utils.Encoder;
-
-import java.nio.charset.StandardCharsets;
 
 public class Transfer extends Transaction {
     private final static long MINIMUM_FEE = 100_000_000;

--- a/src/main/java/com/ltonetwork/client/utils/CryptoUtil.java
+++ b/src/main/java/com/ltonetwork/client/utils/CryptoUtil.java
@@ -7,7 +7,10 @@ import com.goterl.lazysodium.interfaces.Box;
 import com.goterl.lazysodium.interfaces.GenericHash;
 import com.goterl.lazysodium.interfaces.Sign;
 import com.goterl.lazysodium.utils.LibraryLoader;
-import com.ltonetwork.client.types.*;
+import com.ltonetwork.client.types.Encoding;
+import com.ltonetwork.client.types.KeyPair;
+import com.ltonetwork.client.types.PrivateKey;
+import com.ltonetwork.client.types.PublicKey;
 
 import java.nio.charset.StandardCharsets;
 

--- a/src/test/java/com/ltonetwork/client/TestUtil.java
+++ b/src/test/java/com/ltonetwork/client/TestUtil.java
@@ -10,13 +10,13 @@ import java.nio.charset.StandardCharsets;
 public class TestUtil {
     public static Account createAccount() {
         KeyPair sign = new KeyPair(
-                new PublicKey(Encoder.base58Decode("FkU1XyfrCftc4pQKXCrrDyRLSnifX1SMvmx1CYiiyB3Y"), Encoding.RAW),
-                new PrivateKey(Encoder.base58Decode("wJ4WH8dD88fSkNdFQRjaAhjFUZzZhV5yiDLDwNUnp6bYwRXrvWV8MJhQ9HL9uqMDG1n7XpTGZx7PafqaayQV8Rp"), Encoding.RAW)
+                new PublicKey("FkU1XyfrCftc4pQKXCrrDyRLSnifX1SMvmx1CYiiyB3Y", Encoding.BASE58),
+                new PrivateKey("wJ4WH8dD88fSkNdFQRjaAhjFUZzZhV5yiDLDwNUnp6bYwRXrvWV8MJhQ9HL9uqMDG1n7XpTGZx7PafqaayQV8Rp", Encoding.BASE58)
         );
 
         KeyPair encrypt = new KeyPair(
-                new PublicKey(Encoder.base58Decode("BnjFJJarge15FiqcxrB7Mzt68nseBXXR4LQ54qFBsWJN"), Encoding.RAW),
-                new PrivateKey(Encoder.base58Decode("BVv1ZuE3gKFa6krwWJQwEmrLYUESuUabNCXgYTmCoBt6"), Encoding.RAW)
+                new PublicKey("BnjFJJarge15FiqcxrB7Mzt68nseBXXR4LQ54qFBsWJN", Encoding.BASE58),
+                new PrivateKey("BVv1ZuE3gKFa6krwWJQwEmrLYUESuUabNCXgYTmCoBt6", Encoding.BASE58)
         );
 
         Address address = new Address("3N51gbw5W3xvSkcAXtLnXc3SQh2m9e6TBcy");

--- a/src/test/java/com/ltonetwork/client/core/transaction/AnchorTest.java
+++ b/src/test/java/com/ltonetwork/client/core/transaction/AnchorTest.java
@@ -24,7 +24,7 @@ public class AnchorTest {
     @Before
     public void init() {
         chainId = 84;
-        tx = new Anchor("8A8TXZioKiCpKBt7dYx8yAEwnWGhp", Encoding.BASE58);
+        tx = new Anchor("8A8TXZioKiCpKBt7dYx8yAEwnWGhp", Encoding.RAW);
     }
 
     @Test
@@ -32,7 +32,7 @@ public class AnchorTest {
         Account account = TestUtil.createAccount();
         tx.signWith(account);
 
-        assertEquals(101, tx.toBinary().length);
+        assertEquals(83, tx.toBinary().length);
     }
 
     @Test
@@ -45,12 +45,12 @@ public class AnchorTest {
 
     @Test
     public void testGetHashes() {
-        assertEquals("8A8TXZioKiCpKBt7dYx8yAEwnWGhp", tx.getHashes(Encoding.BASE58)[0]);
+        assertEquals("8A8TXZioKiCpKBt7dYx8yAEwnWGhp", tx.getHashes(Encoding.RAW)[0]);
     }
 
     @Test
     public void testGetHash() {
-        assertEquals("8A8TXZioKiCpKBt7dYx8yAEwnWGhp", tx.getHash(Encoding.BASE58));
+        assertEquals("8A8TXZioKiCpKBt7dYx8yAEwnWGhp", tx.getHash(Encoding.RAW));
     }
 
     @Test
@@ -59,7 +59,7 @@ public class AnchorTest {
         expectedEx.expectMessage("Method 'getHash' can't be used on a multi-anchor tx");
 
         tx.addHash("test", Encoding.RAW);
-        assertEquals("8A8TXZioKiCpKBt7dYx8yAEwnWGhk", tx.getHash(Encoding.BASE58));
+        assertEquals("8A8TXZioKiCpKBt7dYx8yAEwnWGhk", tx.getHash(Encoding.RAW));
     }
 
     @Test
@@ -80,11 +80,11 @@ public class AnchorTest {
                         "  \"timestamp\": 1538728794530,\n" +
                         "  \"proofs\": [\"65E82MLn6RdF7Y2VrdtFWkHd97teqLSwVdbGyEfy7x6aczkHRDZMvNUfdTAYgqDXzDDKKEkQqVhMVMg6EEEvE3C3\"],\n" +
                         "  \"version\": 2,\n" +
-                        "  \"anchors\": [\"3MsE8Jfjkh2zaZ1LCGqaDzB5nAYw5FXhfCx\"],\n" +
+                        "  \"anchors\": [\"3Z7yhiFYtYVXHkLXMKLkzkCqYxnRmdMRcutGYba7\"],\n" + // base58 encoding of "8A8TXZioKiCpKBt7dYx8yAEwnWGhp"
                         "  \"height\": 22654\n" +
                         "}", false);
 
         Anchor jsonTx = new Anchor(json);
-        assertEquals(106, jsonTx.toBinary().length);
+        assertEquals(83, jsonTx.toBinary().length);
     }
 }

--- a/src/test/java/com/ltonetwork/client/core/transaction/AssociationTest.java
+++ b/src/test/java/com/ltonetwork/client/core/transaction/AssociationTest.java
@@ -45,7 +45,7 @@ public class AssociationTest {
 
     @Test
     public void testGetHash() {
-        assertEquals("EeNE3sD", tx.getHash());
+        assertEquals("3fkSoZ", tx.getHash());
     }
 
     @Test

--- a/src/test/java/com/ltonetwork/client/core/transaction/AssociationTest.java
+++ b/src/test/java/com/ltonetwork/client/core/transaction/AssociationTest.java
@@ -24,7 +24,7 @@ public class AssociationTest {
 
     @Before
     public void init() {
-        tx = new Association(new Address("3MsE8Jfjkh2zaZ1LCGqaDzB5nAYw5FXhfCx"), 1, "hash", Encoding.BASE58);
+        tx = new Association(new Address("3MsE8Jfjkh2zaZ1LCGqaDzB5nAYw5FXhfCx"), 1, "hash", Encoding.RAW);
     }
 
     @Test
@@ -32,7 +32,7 @@ public class AssociationTest {
         Account account = TestUtil.createAccount();
         tx.signWith(account);
 
-        assertEquals(203, tx.toBinary().length);
+        assertEquals(88, tx.toBinary().length);
     }
 
     @Test
@@ -58,7 +58,7 @@ public class AssociationTest {
         Association txNoHash = new Association(new Address("3MsE8Jfjkh2zaZ1LCGqaDzB5nAYw5FXhfCx"), 1);
         txNoHash.signWith(account);
 
-        assertEquals(190, txNoHash.toBinary().length);
+        assertEquals(82, txNoHash.toBinary().length);
 
         txNoHash.getHash();
     }
@@ -78,12 +78,12 @@ public class AssociationTest {
                         "  \"recipient\": \"3Mv7ajrPLKewkBNqfxwRZoRwW6fziehp7dQ\",\n" +
                         "  \"party\": \"3N51gbw5W3xvSkcAXtLnXc3SQh2m9e6TBcy\",\n" +
                         "  \"associationType\": \"1\",\n" +
-                        "  \"hash\": \"hash\",\n" +
+                        "  \"hash\": \"3fkSoZ\",\n" + //base58 of "hash"
                         "  \"height\": 22654\n" +
                         "}", false);
 
         Association jsonTx = new Association(json);
-        assertEquals(117, jsonTx.toBinary().length);
+        assertEquals(88, jsonTx.toBinary().length);
     }
 
     @Test
@@ -108,7 +108,7 @@ public class AssociationTest {
                         "}", false);
 
         Association jsonTx = new Association(json);
-        assertEquals(106, jsonTx.toBinary().length);
+        assertEquals(82, jsonTx.toBinary().length);
 
         jsonTx.getHash();
     }

--- a/src/test/java/com/ltonetwork/client/core/transaction/CancelLeaseTest.java
+++ b/src/test/java/com/ltonetwork/client/core/transaction/CancelLeaseTest.java
@@ -22,7 +22,7 @@ public class CancelLeaseTest {
 
     @Before
     public void init() {
-        tx = new CancelLease("3MsE8Jfjkh2zaZ1LCGqaDzB5nAYw5FXhfCx");
+        tx = new CancelLease("3MsE8Jfjkh2zaZ1LCGqaDzB5nAYw5FXh");
     }
 
     @Test
@@ -30,7 +30,7 @@ public class CancelLeaseTest {
         Account account = TestUtil.createAccount();
         tx.signWith(account);
 
-        assertEquals(160, tx.toBinary().length);
+        assertEquals(83, tx.toBinary().length);
     }
 
     @Test
@@ -53,11 +53,11 @@ public class CancelLeaseTest {
                         "  \"timestamp\": 1538728794530,\n" +
                         "  \"proofs\": [\"65E82MLn6RdF7Y2VrdtFWkHd97teqLSwVdbGyEfy7x6aczkHRDZMvNUfdTAYgqDXzDDKKEkQqVhMVMg6EEEvE3C3\"],\n" +
                         "  \"version\": 2,\n" +
-                        "  \"leaseId\": \"3MsE8Jfjkh2zaZ1LCGqaDzB5nAYw5FXhfCx\",\n" +
+                        "  \"leaseId\": \"3MsE8Jfjkh2zaZ1LCGqaDzB5nAYw5FXh\",\n" +
                         "  \"height\": 22654\n" +
                         "}", false);
 
         CancelLease jsonTx = new CancelLease(json);
-        assertEquals(76, jsonTx.toBinary().length);
+        assertEquals(83, jsonTx.toBinary().length);
     }
 }

--- a/src/test/java/com/ltonetwork/client/core/transaction/CancelSponsorTest.java
+++ b/src/test/java/com/ltonetwork/client/core/transaction/CancelSponsorTest.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.assertEquals;
 
 
 public class CancelSponsorTest {
-    byte chainId;
     CancelSponsor tx;
 
     @Rule
@@ -31,7 +30,7 @@ public class CancelSponsorTest {
         Account account = TestUtil.createAccount();
         tx.signWith(account);
 
-        assertEquals(186, tx.toBinary().length);
+        assertEquals(77, tx.toBinary().length);
     }
 
     @Test
@@ -59,6 +58,6 @@ public class CancelSponsorTest {
                         "}", false);
 
         CancelSponsor jsonTx = new CancelSponsor(json);
-        assertEquals(102, jsonTx.toBinary().length);
+        assertEquals(77, jsonTx.toBinary().length);
     }
 }

--- a/src/test/java/com/ltonetwork/client/core/transaction/LeaseTest.java
+++ b/src/test/java/com/ltonetwork/client/core/transaction/LeaseTest.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.assertEquals;
 
 
 public class LeaseTest {
-    byte chainId;
     Lease tx;
 
     @Rule
@@ -31,7 +30,7 @@ public class LeaseTest {
         Account account = TestUtil.createAccount();
         tx.signWith(account);
 
-        assertEquals(110, tx.toBinary().length);
+        assertEquals(84, tx.toBinary().length);
     }
 
     @Test
@@ -60,6 +59,6 @@ public class LeaseTest {
                         "}", false);
 
         Lease jsonTx = new Lease(json);
-        assertEquals(110, jsonTx.toBinary().length);
+        assertEquals(84, jsonTx.toBinary().length);
     }
 }

--- a/src/test/java/com/ltonetwork/client/core/transaction/MassTransferTest.java
+++ b/src/test/java/com/ltonetwork/client/core/transaction/MassTransferTest.java
@@ -27,11 +27,11 @@ public class MassTransferTest {
     }
 
     @Test
-    public void testToBinaryNoAttachment() {
+    public void testToBinaryNoTransferNoAttachment() {
         Account account = TestUtil.createAccount();
         tx.signWith(account);
 
-        assertEquals(80, tx.toBinary().length);
+        assertEquals(52, tx.toBinary().length);
     }
 
     @Test
@@ -40,7 +40,7 @@ public class MassTransferTest {
         tx.signWith(account);
         tx.setAttachment("test");
 
-        assertEquals(88, tx.toBinary().length);
+        assertEquals(58, tx.toBinary().length);
     }
 
     @Test
@@ -77,12 +77,32 @@ public class MassTransferTest {
                         "      \"recipient\": \"3MwGRJ1cbCQgP3mSGMR6pR1EJzXAD3e6Bvu\",\n" +
                         "      \"amount\": 100000000\n" +
                         "    }],\n" +
-                        "  \"attachment\": \"attachment\",\n" +
+                        "  \"attachment\": \"3yZe7d\",\n" + // base58 encoded "test"
                         "  \"height\": 22654\n" +
                         "}", false);
 
         MassTransfer jsonTx = new MassTransfer(json);
-        assertEquals(126, jsonTx.toBinary().length);
+        assertEquals(92, jsonTx.toBinary().length);
+    }
+
+    @Test
+    public void testCreateWithJsonNoTransferNoAttachment() {
+        JsonObject json = new JsonObject(
+                "{\n" +
+                        "  \"type\": 11,\n" +
+                        "  \"id\": \"oYv8LBTsLRyAq1w7n9UXudAf5Luu9CuRXkYSnxLX2oa\",\n" +
+                        "  \"sender\": \"3N51gbw5W3xvSkcAXtLnXc3SQh2m9e6TBcy\",\n" +
+                        "  \"senderPublicKey\": \"8wFR3b8WnbFaxQEdRnogTqC5doYUrotm3P7upvxPaWUo\",\n" +
+                        "  \"fee\": 100000,\n" +
+                        "  \"timestamp\": 1538728794530,\n" +
+                        "  \"proofs\": [\"65E82MLn6RdF7Y2VrdtFWkHd97teqLSwVdbGyEfy7x6aczkHRDZMvNUfdTAYgqDXzDDKKEkQqVhMVMg6EEEvE3C3\"],\n" +
+                        "  \"version\": 1,\n" +
+                        "  \"transfers\": [],\n" +
+                        "  \"height\": 22654\n" +
+                        "}", false);
+
+        MassTransfer jsonTx = new MassTransfer(json);
+        assertEquals(52, jsonTx.toBinary().length);
     }
 
     @Test
@@ -97,13 +117,13 @@ public class MassTransferTest {
                         "  \"timestamp\": 1538728794530,\n" +
                         "  \"proofs\": [\"65E82MLn6RdF7Y2VrdtFWkHd97teqLSwVdbGyEfy7x6aczkHRDZMvNUfdTAYgqDXzDDKKEkQqVhMVMg6EEEvE3C3\"],\n" +
                         "  \"version\": 1,\n" +
+                        "  \"attachment\": \"3yZe7d\",\n" + // base58 encoded "test"
                         "  \"transfers\": [],\n" +
-                        "  \"attachment\": \"attachment\",\n" +
                         "  \"height\": 22654\n" +
                         "}", false);
 
         MassTransfer jsonTx = new MassTransfer(json);
-        assertEquals(92, jsonTx.toBinary().length);
+        assertEquals(58, jsonTx.toBinary().length);
     }
 
     @Test
@@ -126,6 +146,6 @@ public class MassTransferTest {
                         "}", false);
 
         MassTransfer jsonTx = new MassTransfer(json);
-        assertEquals(114, jsonTx.toBinary().length);
+        assertEquals(86, jsonTx.toBinary().length);
     }
 }

--- a/src/test/java/com/ltonetwork/client/core/transaction/RevokeAssociationTest.java
+++ b/src/test/java/com/ltonetwork/client/core/transaction/RevokeAssociationTest.java
@@ -1,5 +1,6 @@
 package com.ltonetwork.client.core.transaction;
 
+import com.google.common.hash.Hasher;
 import com.ltonetwork.client.TestUtil;
 import com.ltonetwork.client.core.Account;
 import com.ltonetwork.client.core.transacton.RevokeAssociation;
@@ -7,10 +8,13 @@ import com.ltonetwork.client.exceptions.BadMethodCallException;
 import com.ltonetwork.client.types.Address;
 import com.ltonetwork.client.types.Encoding;
 import com.ltonetwork.client.types.JsonObject;
+import com.ltonetwork.client.utils.Encoder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 
@@ -23,15 +27,14 @@ public class RevokeAssociationTest {
 
     @Before
     public void init() {
-        tx = new RevokeAssociation(new Address("3MsE8Jfjkh2zaZ1LCGqaDzB5nAYw5FXhfCx"), 1, "hash", Encoding.BASE58);
+        tx = new RevokeAssociation(new Address("3N3Cn2pYtqzj7N9pviSesNe8KG9Cmb718Y1"), 1, "hash", Encoding.RAW);
     }
 
     @Test
     public void testToBinary() {
         Account account = TestUtil.createAccount();
         tx.signWith(account);
-
-        assertEquals(203, tx.toBinary().length);
+        assertEquals(88, tx.toBinary().length);
     }
 
     @Test
@@ -44,7 +47,7 @@ public class RevokeAssociationTest {
 
     @Test
     public void testGetHash() {
-        assertEquals("EeNE3sD", tx.getHash());
+        assertEquals("3fkSoZ", tx.getHash());
     }
 
     @Test
@@ -54,10 +57,10 @@ public class RevokeAssociationTest {
 
         Account account = TestUtil.createAccount();
 
-        RevokeAssociation txNoHash = new RevokeAssociation(new Address("3MsE8Jfjkh2zaZ1LCGqaDzB5nAYw5FXhfCx"), 1);
+        RevokeAssociation txNoHash = new RevokeAssociation(new Address("3N3Cn2pYtqzj7N9pviSesNe8KG9Cmb718Y1"), 1);
         txNoHash.signWith(account);
 
-        assertEquals(190, txNoHash.toBinary().length);
+        assertEquals(82, txNoHash.toBinary().length);
 
         txNoHash.getHash();
     }
@@ -68,21 +71,21 @@ public class RevokeAssociationTest {
                 "{\n" +
                         "  \"type\": 17,\n" +
                         "  \"id\": \"oYv8LBTsLRyAq1w7n9UXudAf5Luu9CuRXkYSnxLX2oa\",\n" +
-                        "  \"sender\": \"3N51gbw5W3xvSkcAXtLnXc3SQh2m9e6TBcy\",\n" +
+                        "  \"sender\": \"3MsE8Jfjkh2zaZ1LCGqaDzB5nAYw5FXhfCx\",\n" +
                         "  \"senderPublicKey\": \"8wFR3b8WnbFaxQEdRnogTqC5doYUrotm3P7upvxPaWUo\",\n" +
                         "  \"fee\": 100000,\n" +
                         "  \"timestamp\": 1538728794530,\n" +
                         "  \"signature\": \"5Ae37E2XfWXYPSgLp1TTM69noSWnDJrRGgk2Pb6aSptDdzU2yteitoYfzk91x5oRuT3BNhu1zFyJ9iND4RbFUbBk\",\n" +
                         "  \"version\": 1,\n" +
                         "  \"recipient\": \"3Mv7ajrPLKewkBNqfxwRZoRwW6fziehp7dQ\",\n" +
-                        "  \"party\": \"3N51gbw5W3xvSkcAXtLnXc3SQh2m9e6TBcy\",\n" +
+                        "  \"party\": \"3MsE8Jfjkh2zaZ1LCGqaDzB5nAYw5FXhfCx\",\n" +
                         "  \"associationType\": \"1\",\n" +
-                        "  \"hash\": \"hash\",\n" +
+                        "  \"hash\": \"3fkSoZ\",\n" + //base58 of "hash"
                         "  \"height\": 22654\n" +
                         "}", false);
 
         RevokeAssociation jsonTx = new RevokeAssociation(json);
-        assertEquals(117, jsonTx.toBinary().length);
+        assertEquals(88, jsonTx.toBinary().length);
     }
 
     @Test
@@ -94,20 +97,20 @@ public class RevokeAssociationTest {
                 "{\n" +
                         "  \"type\": 17,\n" +
                         "  \"id\": \"oYv8LBTsLRyAq1w7n9UXudAf5Luu9CuRXkYSnxLX2oa\",\n" +
-                        "  \"sender\": \"3N51gbw5W3xvSkcAXtLnXc3SQh2m9e6TBcy\",\n" +
-                        "  \"senderPublicKey\": \"8wFR3b8WnbFaxQEdRnogTqC5doYUrotm3P7upvxPaWUo\",\n" +
+                        "  \"sender\": \"3MsE8Jfjkh2zaZ1LCGqaDzB5nAYw5FXhfCx\",\n" +
+                        "  \"senderPublicKey\": \"FkU1XyfrCftc4pQKXCrrDyRLSnifX1SMvmx1CYiiyB3Y\",\n" +
                         "  \"fee\": 100000,\n" +
                         "  \"timestamp\": 1538728794530,\n" +
                         "  \"proofs\": [\"65E82MLn6RdF7Y2VrdtFWkHd97teqLSwVdbGyEfy7x6aczkHRDZMvNUfdTAYgqDXzDDKKEkQqVhMVMg6EEEvE3C3\"],\n" +
                         "  \"version\": 1,\n" +
                         "  \"recipient\": \"3Mv7ajrPLKewkBNqfxwRZoRwW6fziehp7dQ\",\n" +
-                        "  \"party\": \"3N51gbw5W3xvSkcAXtLnXc3SQh2m9e6TBcy\",\n" +
+                        "  \"party\": \"3MsE8Jfjkh2zaZ1LCGqaDzB5nAYw5FXhfCx\",\n" +
                         "  \"associationType\": \"1\",\n" +
                         "  \"height\": 22654\n" +
                         "}", false);
 
         RevokeAssociation jsonTx = new RevokeAssociation(json);
-        assertEquals(106, jsonTx.toBinary().length);
+        assertEquals(82, jsonTx.toBinary().length);
 
         jsonTx.getHash();
     }

--- a/src/test/java/com/ltonetwork/client/core/transaction/SetScriptTest.java
+++ b/src/test/java/com/ltonetwork/client/core/transaction/SetScriptTest.java
@@ -21,7 +21,7 @@ public class SetScriptTest {
 
     @Before
     public void init() {
-        tx = new SetScript("3MsE8Jfjkh2zaZ1LCGqaDzB5nAYw5FXhfCx");
+        tx = new SetScript("script");
     }
 
     @Test
@@ -29,7 +29,7 @@ public class SetScriptTest {
         Account account = TestUtil.createAccount();
         tx.signWith(account);
 
-        assertEquals(190, tx.toBinary().length);
+        assertEquals(58, tx.toBinary().length);
     }
 
     @Test
@@ -59,7 +59,7 @@ public class SetScriptTest {
     @Test
     public void testCreateWithJson() {
         SetScript jsonTx = createFromJson();
-        assertEquals(84, jsonTx.toBinary().length);
+        assertEquals(58, jsonTx.toBinary().length);
     }
 
     @Test

--- a/src/test/java/com/ltonetwork/client/core/transaction/SponsorTest.java
+++ b/src/test/java/com/ltonetwork/client/core/transaction/SponsorTest.java
@@ -30,7 +30,7 @@ public class SponsorTest {
         Account account = TestUtil.createAccount();
         tx.signWith(account);
 
-        assertEquals(186, tx.toBinary().length);
+        assertEquals(77, tx.toBinary().length);
     }
 
     @Test
@@ -58,6 +58,6 @@ public class SponsorTest {
                         "}", false);
 
         Sponsor jsonTx = new Sponsor(json);
-        assertEquals(102, jsonTx.toBinary().length);
+        assertEquals(77, jsonTx.toBinary().length);
     }
 }

--- a/src/test/java/com/ltonetwork/client/core/transaction/TransferTest.java
+++ b/src/test/java/com/ltonetwork/client/core/transaction/TransferTest.java
@@ -39,7 +39,7 @@ public class TransferTest {
         Account account = TestUtil.createAccount();
         tx.signWith(account);
 
-        assertEquals(110, tx.toBinary().length);
+        assertEquals(84, tx.toBinary().length);
     }
 
     @Test
@@ -48,7 +48,7 @@ public class TransferTest {
         tx.signWith(account);
         tx.setAttachment("test");
 
-        assertEquals(119, tx.toBinary().length);
+        assertEquals(91, tx.toBinary().length);
     }
 
     @Test
@@ -64,8 +64,7 @@ public class TransferTest {
         Account account = TestUtil.createAccount();
         tx.signWith(account);
 
-        byte exp = 84;
-        assertEquals(exp, tx.getNetwork());
+        assertEquals((byte) 84, tx.getNetwork());
     }
 
     @Test
@@ -87,7 +86,7 @@ public class TransferTest {
                         "}", false);
 
         Transfer jsonTx = new Transfer(json);
-        assertEquals(110, jsonTx.toBinary().length);
+        assertEquals(84, jsonTx.toBinary().length);
     }
 
     @Test


### PR DESCRIPTION
Beforehand I was calculating the binary representation wrong. Now I've verified all the lengths to be the exact ones specified in the docs (V2 though, not V3).